### PR TITLE
Entity Framework + Database Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/developersecrets.json

--- a/Tech@HubAPI/Tech@HubAPI/Models/Author.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/Author.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Tech_HubAPI.Models
+{
+	public class Author
+	{
+		public int Id { get; set; }
+
+		public string Name { get; set; }
+
+		public List<Book> Books { get; set; }
+	}
+}

--- a/Tech@HubAPI/Tech@HubAPI/Models/Book.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/Book.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Tech_HubAPI.Models
+{
+	public class Book
+	{
+		public int Id { get; set; }
+
+		public string Title { get; set; }
+
+		public DateTime PublishDate { get; set; }
+
+		public int AuthorId { get; set;}
+
+		public Author Author { get; set; }
+	}
+}

--- a/Tech@HubAPI/Tech@HubAPI/Models/DatabaseContext.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/DatabaseContext.cs
@@ -14,6 +14,28 @@ namespace Tech_HubAPI.Models
 			: base(options)
 		{ }
 
+		public DbSet<Book> Books { get; set; }
+		public DbSet<Author> Authors { get; set; }
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			base.OnModelCreating(modelBuilder);
+
+			modelBuilder.Entity<Book>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+				entity.HasOne(e => e.Author)
+					.WithMany(a => a.Books);
+			});
+
+			modelBuilder.Entity<Author>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+				entity.HasMany(a => a.Books)
+					.WithOne(b => b.Author);
+			});
+		}
+
 		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 		{
 			if (!optionsBuilder.IsConfigured)

--- a/Tech@HubAPI/Tech@HubAPI/Models/DatabaseContext.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/DatabaseContext.cs
@@ -1,14 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Tech_HubAPI.Models
 {
 	public partial class DatabaseContext : DbContext
 	{
 		private string _connectionString;
+
+		public DatabaseContext(string connectionString)
+		{
+			_connectionString = connectionString;
+		}
 
 		public DatabaseContext(DbContextOptions<DatabaseContext> options)
 			: base(options)

--- a/Tech@HubAPI/Tech@HubAPI/Models/DatabaseContext.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/DatabaseContext.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tech_HubAPI.Models
+{
+	public partial class DatabaseContext : DbContext
+	{
+		private string _connectionString;
+
+		public DatabaseContext(DbContextOptions<DatabaseContext> options)
+			: base(options)
+		{ }
+
+		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+		{
+			if (!optionsBuilder.IsConfigured)
+			{
+				optionsBuilder.UseMySql(_connectionString, ServerVersion.AutoDetect(_connectionString));
+			}
+		}
+	}
+}

--- a/Tech@HubAPI/Tech@HubAPI/Program.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Program.cs
@@ -18,6 +18,10 @@ namespace Tech_HubAPI
 
 		public static IHostBuilder CreateHostBuilder(string[] args) =>
 			Host.CreateDefaultBuilder(args)
+				.ConfigureAppConfiguration((hostContext, config) =>
+				{
+					config.AddJsonFile("developersecrets.json", optional: true, reloadOnChange: true);
+				})
 				.ConfigureWebHostDefaults(webBuilder =>
 				{
 					webBuilder.UseStartup<Startup>();

--- a/Tech@HubAPI/Tech@HubAPI/Program.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Program.cs
@@ -1,11 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Tech_HubAPI
 {

--- a/Tech@HubAPI/Tech@HubAPI/Startup.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Startup.cs
@@ -1,17 +1,10 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Tech_HubAPI.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -36,7 +29,7 @@ namespace Tech_HubAPI
 				options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
 			});
 
-			services.AddSingleton<IConfiguration>(Configuration);
+			services.AddSingleton(Configuration);
 
 			services.AddControllers();
 			services.AddSwaggerGen(c =>

--- a/Tech@HubAPI/Tech@HubAPI/Startup.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -12,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Tech_HubAPI.Models;
 
 namespace Tech_HubAPI
 {
@@ -27,6 +29,12 @@ namespace Tech_HubAPI
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)
 		{
+			string connectionString = "";
+
+			services.AddDbContext<DatabaseContext>(options =>
+			{
+				options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
+			});
 
 			services.AddControllers();
 			services.AddSwaggerGen(c =>

--- a/Tech@HubAPI/Tech@HubAPI/Tech@HubAPI.csproj
+++ b/Tech@HubAPI/Tech@HubAPI/Tech@HubAPI.csproj
@@ -11,7 +11,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+    <PackageReference Include="MySql.Data" Version="8.0.27" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 

--- a/Tech@HubAPI/Tech@HubAPITest/Tech@HubAPITest.csproj
+++ b/Tech@HubAPI/Tech@HubAPITest/Tech@HubAPITest.csproj
@@ -10,7 +10,10 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MySql.Data" Version="8.0.27" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Installs the packages for connecting to a MySQL database and sets up the DatabaseContext service provider. This feature expects the following file to exist in the ```Tech@HubAPI/Tech@HubAPI``` folder:
```developersecrets.json``` (currently git-ignored)
```
{
	"ConnectionStrings": {
		"MySqlDatabase": "server=localhost; port=3306; uid=yourusername; password=yourpassword; database=tech-at-hub;"
	}
}
```
Containing the username and password of your MySQL database.

Also adds two example database objects, ```Book``` and ```Author```, to demonstrate how to create new ones. These can be removed when they are no longer needed.

Closes #6 
Closes #7 