### PR TITLE
JWT Authentication

### DIFF
--- a/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
@@ -1,12 +1,18 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Security.Claims;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Tech_HubAPI.Models;
+using Tech_HubAPI.Services;
 
 namespace GitTest.Controllers
 {
@@ -15,13 +21,44 @@ namespace GitTest.Controllers
 	public class AuthController : ControllerBase
 	{
 		private readonly ILogger<AuthController> _logger;
+		private readonly JwtService _jwt;
+		private readonly DatabaseContext _dbContext;
 
-		public AuthController(ILogger<AuthController> logger)
+		public AuthController(DatabaseContext dbContext, JwtService jwt, ILogger<AuthController> logger)
 		{
+			_jwt = jwt;
+			_dbContext = dbContext;
 			_logger = logger;
 		}
 
+		[HttpPost]
+		[Route("login")]
+		public IActionResult Login([FromBody] Credentials credentials)
+		{
+			// https://delushaandelu.medium.com/jwt-auth-in-asp-net-core-353595b9b7c4
+			var user = _dbContext.Users.Where(u => u.Username == credentials.Username).FirstOrDefault();
+
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			// Check password here
+
+			var token = _jwt.GenerateToken(new List<Claim>
+			{
+				new Claim(ClaimTypes.Name, user.Username),
+			});
+
+			return Ok(new
+			{
+				token = _jwt.SerializeToken(token),
+				expiration = token.ValidTo
+			});
+		}
+
 		[HttpGet]
+		[Route("gitclient")]
 		public ActionResult Get()
 		{
 			// Manual implementation of HTTP Basic authentication

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
@@ -47,7 +47,9 @@ namespace GitTest.Controllers
 
 			var token = _jwt.GenerateToken(new List<Claim>
 			{
-				new Claim(ClaimTypes.Name, user.Username),
+				new Claim("Username", user.Username),
+				new Claim("FullName", user.FirstName + " " + user.LastName),
+				new Claim("Id", user.Id.ToString()),
 			});
 
 			return Ok(new

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/ControllerBaseExtensions.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/ControllerBaseExtensions.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using Tech_HubAPI.Models;
+
+namespace Tech_HubAPI.Controllers
+{
+    public static class ControllerBaseExtensions
+    {
+        /// <summary>
+        /// Returns the user who made the current request. If the current user is unauthenticated,
+        /// returns null.
+        /// </summary>
+        /// <param name="controller">Current controller class.</param>
+        /// <param name="dbContext">A valid <see cref="DatabaseContext"/> to retrieve the
+        /// user from the database.</param>
+        /// <returns>User who made the current request.</returns>
+        /// <exception cref="Exception">If there was an error parsing the users identifier from
+        /// the JWT token.</exception>
+        public static User GetUser(this ControllerBase controller, DatabaseContext dbContext)
+        {
+            if (controller.User == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                int userId = int.Parse(controller.User.FindFirst("Id").Value);
+                var user = dbContext.Users.Find(userId);
+
+                if (user == null)
+                {
+                    return null;
+                }
+
+                // detach the entity so the caller doesn't need to worry about accidentally modifying it
+                dbContext.Entry(user).State = EntityState.Detached;
+                return user;
+            }
+            catch
+            {
+                throw new Exception("Unable to retrieve user ID from the JWT token passed in this request.");
+            }
+        }
+    }
+}

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/UserController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/UserController.cs
@@ -1,20 +1,5 @@
-﻿using Google.Protobuf.Collections;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Numerics;
-using System.Security.Claims;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Mvc;
 using Tech_HubAPI.Models;
-using Ubiety.Dns.Core;
 
 namespace Tech_HubAPI.Controllers
 {
@@ -22,42 +7,11 @@ namespace Tech_HubAPI.Controllers
 	[ApiController]
 	public class UserController : ControllerBase
 	{
-		private readonly IConfiguration _configuration;
 		private readonly DatabaseContext _dbContext;
 
-		public UserController(DatabaseContext dbContext, IConfiguration configuration)
-{
-			_configuration = configuration;
-			_dbContext = dbContext;
-		}
-
-		[HttpPost]
-		[Route("login")]
-		public IActionResult Login([FromBody] string username, [FromBody] string password)
+		public UserController(DatabaseContext dbContext)
 		{
-			// https://delushaandelu.medium.com/jwt-auth-in-asp-net-core-353595b9b7c4
-			var user = _dbContext.Users.Where(u => u.Username == username).FirstOrDefault();
-			// Check password here
-
-			var authClaims = new List<Claim>
-			{
-				//new Claim(ClaimTypes.Name, user.Username),
-				new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-			};	
-				
-			var authSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["JWT: SecretKey"])); 
-			var token = new JwtSecurityToken(
-				issuer: _configuration["JWT: ValidIssuer"],
-				audience: _configuration["JWT: ValidAudience"],
-				expires: DateTime.Now.AddHours(3),
-				claims: authClaims,
-				signingCredentials: new SigningCredentials(authSigningKey, SecurityAlgorithms.HmacSha256)); 
-				
-			return Ok(new
-				{
-					token = new JwtSecurityTokenHandler().WriteToken(token),
-					expiration = token.ValidTo
-				});
+			_dbContext = dbContext;
 		}
 	}
 }

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/UserController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/UserController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
 using Tech_HubAPI.Models;
 
 namespace Tech_HubAPI.Controllers

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/UserController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/UserController.cs
@@ -1,0 +1,63 @@
+﻿using Google.Protobuf.Collections;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Numerics;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using Tech_HubAPI.Models;
+using Ubiety.Dns.Core;
+
+namespace Tech_HubAPI.Controllers
+{
+	[Route("[controller]")]
+	[ApiController]
+	public class UserController : ControllerBase
+	{
+		private readonly IConfiguration _configuration;
+		private readonly DatabaseContext _dbContext;
+
+		public UserController(DatabaseContext dbContext, IConfiguration configuration)
+{
+			_configuration = configuration;
+			_dbContext = dbContext;
+		}
+
+		[HttpPost]
+		[Route("login")]
+		public IActionResult Login([FromBody] string username, [FromBody] string password)
+		{
+			// https://delushaandelu.medium.com/jwt-auth-in-asp-net-core-353595b9b7c4
+			var user = _dbContext.Users.Where(u => u.Username == username).FirstOrDefault();
+			// Check password here
+
+			var authClaims = new List<Claim>
+			{
+				//new Claim(ClaimTypes.Name, user.Username),
+				new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+			};	
+				
+			var authSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["JWT: SecretKey"])); 
+			var token = new JwtSecurityToken(
+				issuer: _configuration["JWT: ValidIssuer"],
+				audience: _configuration["JWT: ValidAudience"],
+				expires: DateTime.Now.AddHours(3),
+				claims: authClaims,
+				signingCredentials: new SigningCredentials(authSigningKey, SecurityAlgorithms.HmacSha256)); 
+				
+			return Ok(new
+				{
+					token = new JwtSecurityTokenHandler().WriteToken(token),
+					expiration = token.ValidTo
+				});
+		}
+	}
+}

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/WeatherForecastController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/WeatherForecastController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 namespace Tech_HubAPI.Controllers
 {
 	[ApiController]
+	[Authorize]
 	[Route("[controller]")]
 	public class WeatherForecastController : ControllerBase
 	{

--- a/Tech@HubAPI/Tech@HubAPI/Models/Credentials.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/Credentials.cs
@@ -1,0 +1,8 @@
+﻿namespace Tech_HubAPI.Models
+{
+	public class Credentials
+	{
+		public string Username { get; set; }
+		public string Password { get; set; }
+	}
+}

--- a/Tech@HubAPI/Tech@HubAPI/Services/JwtService.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Services/JwtService.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace Tech_HubAPI.Services
+{
+    public class JwtService
+    {
+        private readonly int _tokenLifetimeSeconds = 60 * 60 * 3;
+        private readonly IConfiguration _configuration;
+
+        public JwtService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public JwtSecurityToken GenerateToken(List<Claim> claims)
+        {
+            var authClaims = new List<Claim>
+            {
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            };
+            authClaims.AddRange(claims);
+
+            var authSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["JWT:SecretKey"]));
+            var token = new JwtSecurityToken(
+                expires: DateTime.Now.AddSeconds(_tokenLifetimeSeconds),
+                claims: authClaims,
+                signingCredentials: new SigningCredentials(authSigningKey, SecurityAlgorithms.HmacSha256));
+
+            return token;
+        }
+
+        public string SerializeToken(JwtSecurityToken token)
+        {
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+}

--- a/Tech@HubAPI/Tech@HubAPI/Startup.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Startup.cs
@@ -9,10 +9,6 @@ using Tech_HubAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Tech_HubAPI.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using static System.Net.Mime.MediaTypeNames;
-using System.Net;
-using System.Reflection.Metadata;
-using Ubiety.Dns.Core;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 
@@ -38,7 +34,11 @@ namespace Tech_HubAPI
 			});
 
 			services.AddSingleton(Configuration);
+<<<<<<< HEAD
 			services.AddSingleton(new Execute());
+=======
+			services.AddSingleton(new JwtService(Configuration));
+>>>>>>> d05b2ad (Implemented JWT token generation and service)
 
 			services.AddControllers();
 			services.AddSwaggerGen(c =>
@@ -66,23 +66,21 @@ namespace Tech_HubAPI
 						}
 					}
 					,new string[] {}
-				}});
-
-				services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+				}});	
+			});
+			
+			services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 					.AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
 					{
 						options.SaveToken = true;
 						options.RequireHttpsMetadata = false;
 						options.TokenValidationParameters = new TokenValidationParameters()
 						{
-							ValidateIssuer = true,
-							ValidateAudience = true,
-							ValidAudience = Configuration["JWT: ValidAudience"],
-							ValidIssuer = Configuration["JWT: ValidIssuer"],
-							IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration["JWT: SecretKey"]))
+							ValidateIssuer = false,
+							ValidateAudience = false,
+							IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration["JWT:SecretKey"]))
 						};
 					});
-			});
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Tech@HubAPI/Tech@HubAPI/Startup.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Startup.cs
@@ -34,11 +34,8 @@ namespace Tech_HubAPI
 			});
 
 			services.AddSingleton(Configuration);
-<<<<<<< HEAD
 			services.AddSingleton(new Execute());
-=======
 			services.AddSingleton(new JwtService(Configuration));
->>>>>>> d05b2ad (Implemented JWT token generation and service)
 
 			services.AddControllers();
 			services.AddSwaggerGen(c =>

--- a/Tech@HubAPI/Tech@HubAPI/Tech@HubAPI.csproj
+++ b/Tech@HubAPI/Tech@HubAPI/Tech@HubAPI.csproj
@@ -11,6 +11,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="MySql.Data" Version="8.0.27" />

--- a/Tech@HubGitServer/nginx.conf
+++ b/Tech@HubGitServer/nginx.conf
@@ -24,7 +24,7 @@ http {
 
         location ~ /git(/.*) {
             client_max_body_size 0; # Git pushes can be massive, just to make sure nginx doesn't suddenly cut the connection add this.
-            auth_request /auth;
+            auth_request /auth/gitclient;
             include /etc/nginx/fastcgi_params; # Include the default fastcgi configs
             fastcgi_param SCRIPT_FILENAME /usr/lib/git-core/git-http-backend; # Tells fastcgi to pass the request to the git http backend executable
             fastcgi_param GIT_HTTP_EXPORT_ALL "";
@@ -34,7 +34,7 @@ http {
             fastcgi_pass  unix:/var/run/fcgiwrap.socket; # Pass the request to fastcgi
         }
 
-        location = /auth {
+        location = /auth/gitclient {
             internal;
             proxy_pass http://host.docker.internal:5000;
             proxy_pass_request_body off;


### PR DESCRIPTION
Adds JWT authentication to the request pipeline. Any endpoint marked with the `[Authorize]` attribute will require a valid JWT token to be passed in the request, otherwise it will return a 401. JWT tokens can be retrieved from the `auth/login` endpoint, which requires a valid username and password.

Everyone will need to add this section to their `developersecrets.json` file:
```
"JWT": {
	"SecretKey": "blahblahblahblah"
}
```
The value of the SecretKey can be arbitrary but it must be at least 16 characters.

The way JWT works is very simple.
1. The user sends their username and password to our `auth/login` endpoint (defined in the `AuthController` class)
2. This endpoint checks that their username and password are valid. This isn't being done currently (I left a comment where it should go)
3. If they are valid, a JWT token is generated. The details of this aren't super important, but you can easily Google more info about JWT if you are curious. The generated JWT token is signed using the `SecretKey` mentioned above. It is impossible for someone to forge this signature unless they know the `SecretKey`.
4. The JWT token is sent back to the user (there is a spot on the Swagger page to find it, I can show this at the next meeting maybe)
5. The user can now make a request to a protected endpoint. To protect an endpoint, you use the `[Authorize]` attribute. I did this on the `WeatherForecast` class. The user must include the JWT token they just got in this request. Once our server receives the request, it makes sure the signature is valid using the `SecretKey` again. If everything checks out, we can be sure this user is someone we have previously given a JWT token to, so we can trust them!