### PR TITLE
Added password comparison to auth login route

### DIFF
--- a/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
@@ -22,11 +22,13 @@ namespace GitTest.Controllers
 	{
 		private readonly ILogger<AuthController> _logger;
 		private readonly JwtService _jwt;
+		private readonly HashingService _hashing;
 		private readonly DatabaseContext _dbContext;
 
-		public AuthController(DatabaseContext dbContext, JwtService jwt, ILogger<AuthController> logger)
+		public AuthController(DatabaseContext dbContext, JwtService jwt, HashingService hashing, ILogger<AuthController> logger)
 		{
 			_jwt = jwt;
+			_hashing = hashing;
 			_dbContext = dbContext;
 			_logger = logger;
 		}
@@ -43,7 +45,11 @@ namespace GitTest.Controllers
 				return NotFound();
 			}
 
-			// Check password here
+			byte[] hashedPasswordAttempt = _hashing.HashPassword(credentials.Password, user.Salt);
+			if (hashedPasswordAttempt != user.Password)
+            {
+				return Unauthorized();
+            }
 
 			var token = _jwt.GenerateToken(new List<Claim>
 			{

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
@@ -46,7 +46,7 @@ namespace GitTest.Controllers
 			}
 
 			byte[] hashedPasswordAttempt = _hashing.HashPassword(credentials.Password, user.Salt);
-			if (hashedPasswordAttempt != user.Password)
+			if (!_hashing.ByteCheck(hashedPasswordAttempt, user.Password))
             {
 				return Unauthorized();
             }


### PR DESCRIPTION
Added a comparison to the auth login route to confirm whether a user has the correct password. This works by hashing the password received by the route and comparing it to the hashed password in the DB.