### PR TITLE
Rate limit login attempts and cache remote IP Address

### DIFF
--- a/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
@@ -44,7 +45,33 @@ namespace GitTest.Controllers
                 return NotFound();
             }
 
-            TimeSpan loginInterval = DateTime.Now - user.LastLogin;
+            
+            string? ipNullable = Request.HttpContext.GetServerVariable("REMOTE_ADDR");
+            string ip;
+            if (ipNullable == null)
+            {
+                ip = "localhost";
+            }
+            else
+            {
+                ip = (string)ipNullable;
+            }
+            System.Diagnostics.Debug.WriteLine(ip);
+
+            TimeSpan loginInterval;
+            DateTime now = DateTime.Now;
+
+            if (user.LastLoginAttempt == null)
+            {
+                loginInterval = TimeSpan.Zero;
+            }
+            else
+            {
+                loginInterval = now - (DateTime)user.LastLoginAttempt;
+            }
+
+            user.LastLoginAttempt = now;
+            user.LastLoginAttemptIp = ip;
 
             if (loginInterval.Seconds < minLoginInterval)
             {

--- a/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Controllers/AuthController.cs
@@ -61,14 +61,7 @@ namespace GitTest.Controllers
             TimeSpan loginInterval;
             DateTime now = DateTime.Now;
 
-            if (user.LastLoginAttempt == null)
-            {
-                loginInterval = TimeSpan.Zero;
-            }
-            else
-            {
-                loginInterval = now - (DateTime)user.LastLoginAttempt;
-            }
+            loginInterval = now - user.LastLoginAttempt;
 
             user.LastLoginAttempt = now;
             user.LastLoginAttemptIp = ip;

--- a/Tech@HubAPI/Tech@HubAPI/Models/User.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/User.cs
@@ -38,7 +38,7 @@ namespace Tech_HubAPI.Models
 
         public DateTime BirthDate { get; set; }
 
-        public DateTime LastLoginAttempt { get; set; }
+        public DateTime? LastLoginAttempt { get; set; }
 
         public string? LastLoginAttemptIp { get; set; }
     }

--- a/Tech@HubAPI/Tech@HubAPI/Models/User.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/User.cs
@@ -4,8 +4,6 @@ namespace Tech_HubAPI.Models
 {
     public class User
     {
-        private DateTime lastLogin;
-
         public User(string username, byte[] password, byte[] salt, string email, string firstName,
             string lastName, string description, string? profilePicturePath, DateTime birthDate)
         {
@@ -40,16 +38,8 @@ namespace Tech_HubAPI.Models
 
         public DateTime BirthDate { get; set; }
 
-        public DateTime LastLogin
-        {
-            get
-            {
-                return this.lastLogin;
-            }
-            set
-            {
-                this.lastLogin = DateTime.Now;
-            }
-        }
+        public DateTime LastLoginAttempt { get; set; }
+
+        public string? LastLoginAttemptIp { get; set; }
     }
 }

--- a/Tech@HubAPI/Tech@HubAPI/Models/User.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/User.cs
@@ -38,7 +38,7 @@ namespace Tech_HubAPI.Models
 
         public DateTime BirthDate { get; set; }
 
-        public DateTime? LastLoginAttempt { get; set; }
+        public DateTime LastLoginAttempt { get; set; }
 
         public string? LastLoginAttemptIp { get; set; }
     }

--- a/Tech@HubAPI/Tech@HubAPI/Models/User.cs
+++ b/Tech@HubAPI/Tech@HubAPI/Models/User.cs
@@ -4,6 +4,8 @@ namespace Tech_HubAPI.Models
 {
     public class User
     {
+        private DateTime lastLogin;
+
         public User(string username, byte[] password, byte[] salt, string email, string firstName,
             string lastName, string description, string? profilePicturePath, DateTime birthDate)
         {
@@ -37,5 +39,17 @@ namespace Tech_HubAPI.Models
         public string? ProfilePicturePath { get; set; }
 
         public DateTime BirthDate { get; set; }
+
+        public DateTime LastLogin
+        {
+            get
+            {
+                return this.lastLogin;
+            }
+            set
+            {
+                this.lastLogin = DateTime.Now;
+            }
+        }
     }
 }


### PR DESCRIPTION
Added two nullable data fields to User model: LastLoginAttempt and LastLoginAttemptIp. These are updated on every login attempt, and a HTTP Too Many Requests error will be thrown if login attempts are made within 5 seconds of each other.